### PR TITLE
Fixed editor wrongly executing undo operation

### DIFF
--- a/Markdown.Editor.js
+++ b/Markdown.Editor.js
@@ -586,7 +586,7 @@
 
             var handled = false;
 
-            if (event.ctrlKey || event.metaKey) {
+            if ((event.ctrlKey || event.metaKey) && !event.altKey) {
 
                 // IE and Opera do not support charCode.
                 var keyCode = event.charCode || event.keyCode;
@@ -662,7 +662,7 @@
             util.addEvent(panels.input, "keypress", function (event) {
                 // keyCode 89: y
                 // keyCode 90: z
-                if ((event.ctrlKey || event.metaKey) && (event.keyCode == 89 || event.keyCode == 90)) {
+                if ((event.ctrlKey || event.metaKey) && !evt.altKey && (event.keyCode == 89 || event.keyCode == 90)) {
                     event.preventDefault();
                 }
             });


### PR DESCRIPTION
Hello there,

there's a bug in the editor that triggers undo action when user presses the (right) alt+z key combination, which is used in Polish keyboard layout to achieve the letter "ż". My commit duplicates changes from the official repo of pagedown where it was fixed: https://code.google.com/p/pagedown/source/detail?r=7bf1d3cd5ed557523db65bf5615d53e465816a96#

If the pull request gets merged please update the dependency in django-pagedown, cause that's where I'd like to benefit from it :)
